### PR TITLE
Making unit tests run again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
         }
     },
     "require": {
-        "nikic/php-parser": "1.1.*"
+        "nikic/php-parser": "^1.3"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,7 +17,7 @@
     strict                      = "false"
     verbose                     = "true"
     debug                       = "true"
-    bootstrap                   = "tests/bootstrap.php" >
+    bootstrap                   = "vendor/autoload.php" >
 
     <testsuites>
         <testsuite name="class-info tests">

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -5,7 +5,7 @@ use crodas\ClassInfo\Definition\TClass;
 use crodas\ClassInfo\Definition\TFunction;
 use crodas\ClassInfo\Definition\TProperty;
 
-class ParseTest extends \phpunit_framework_testcase
+class ParseTest extends \PHPUnit_Framework_TestCase
 {
     public function testParse()
     {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,2 +1,0 @@
-<?php
-require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
Hey, I couldn't run the unit tests because `\PHPUnit_Framework_TestCase` was all lower case in ParseTest.
I also removed the bootstrap class and bumped the version of php-parser from 1.0 to 1.3 and up excluding 2.0
